### PR TITLE
[speculative] Convert the RSpec idiom to a generic shared context.

### DIFF
--- a/chef-provisioning-vagrant.gemspec
+++ b/chef-provisioning-vagrant.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/chef/chef-provisioning-vagrant'
 
   s.add_dependency 'chef'
+  s.add_dependency 'cheffish', '>= 1.3.1'  # 1.3.1 adds ability to use let vars in specs.
   s.add_dependency 'chef-provisioning'
 
   s.add_development_dependency 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'vagrant_support'
+require 'vagrant_context'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,5 @@ RSpec.configure do |config|
 
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
+  # config.include ChefServerInclude
 end

--- a/spec/vagrant_context.rb
+++ b/spec/vagrant_context.rb
@@ -6,8 +6,5 @@ RSpec.shared_context "run with driver" do |driver_args|
 
   vagrant_driver = Chef::Provisioning.driver_for_url(driver_args[:driver_string])
 
-  # @@driver = vagrant_driver
-  # def self.driver
-  #   @@driver
-  # end
+  let(:provisioning_driver) { vagrant_driver }
 end

--- a/spec/vagrant_context.rb
+++ b/spec/vagrant_context.rb
@@ -4,7 +4,11 @@ RSpec.shared_context "run with driver" do |driver_args|
 
   include_context "with a chef repo"
 
-  vagrant_driver = Chef::Provisioning.driver_for_url(driver_args[:driver_string])
+  driver_object = Chef::Provisioning.driver_for_url(driver_args[:driver_string])
 
-  let(:provisioning_driver) { vagrant_driver }
+  let(:provisioning_driver) { driver_object }
+
+  def self.with_chef_server(&block)
+    when_the_chef_12_server "is running", server_scope: :context, port: 8900..9000, &block
+  end
 end

--- a/spec/vagrant_context.rb
+++ b/spec/vagrant_context.rb
@@ -8,7 +8,10 @@ RSpec.shared_context "run with driver" do |driver_args|
 
   let(:provisioning_driver) { driver_object }
 
-  def self.with_chef_server(&block)
-    when_the_chef_12_server "is running", server_scope: :context, port: 8900..9000, &block
+  def self.with_chef_server(*options, &block)
+    args = { server_scope: :context, port: 8900..9000 }
+    args = args.merge(options.last) if options.last.is_a?(Hash)
+
+    when_the_chef_12_server "is running", args, &block
   end
 end

--- a/spec/vagrant_context.rb
+++ b/spec/vagrant_context.rb
@@ -1,0 +1,13 @@
+RSpec.shared_context "run with driver" do |driver_args|
+  require 'cheffish/rspec/chef_run_support'
+  extend Cheffish::RSpec::ChefRunSupport
+
+  include_context "with a chef repo"
+
+  vagrant_driver = Chef::Provisioning.driver_for_url(driver_args[:driver_string])
+
+  # @@driver = vagrant_driver
+  # def self.driver
+  #   @@driver
+  # end
+end

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -13,7 +13,7 @@ describe "Chef::Provisioning::Vagrant" do
         }.not_to raise_error
       end
 
-      it "can use a let variable in a recipe" do
+      it "can use a let variable in a recipe, no matter what kind of RSpec-ception we engage in" do
         expect_converge {
           log "should be able to use let_var as '#{let_var}' with no error."
         }.not_to raise_error

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -22,6 +22,14 @@ describe "Chef::Provisioning::Vagrant" do
       it "has access to the driver object" do
         expect(provisioning_driver.driver_url).to start_with("vagrant:")
       end
+
+      it "has a running Chef-Zero server available" do
+        expect_recipe {
+          chef_data_bag "spec-#{Time.now.to_i}" do
+            action :delete
+          end
+        }.to be_truthy
+      end
     end
   end
 end

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -1,11 +1,15 @@
 describe "Chef::Provisioning::Vagrant" do
   extend VagrantSupport
-  # include VagrantConfig   # uncomment to get `chef_config` or to mix in code.
 
   when_the_chef_12_server "exists", server_scope: :context, port: 8900..9000 do
     with_vagrant "integration tests" do
       context "machine resource" do
+        let(:let_var) { "a let variable in the enclosing context"}
+
         it "doesn't run any tests" do
+          expect_converge {
+            log "should be able to use let_var as '#{let_var}' with no error."
+          }.not_to raise_error
         end
       end
     end

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -1,18 +1,26 @@
 describe "Chef::Provisioning::Vagrant" do
   include_context "run with driver", :driver_string => "vagrant"
 
-  when_the_chef_12_server "exists", server_scope: :context, port: 8900..9000 do
-    context "machine resource" do
+  with_chef_server do
+    context "the test environment" do
       let(:let_var) { "a let variable in the enclosing context"}
 
-      it "uses a Vagrant resource and a let variable" do
+      it "can use a Vagrant resource" do
         expect_converge {
           vagrant_box "should load the resource with no errors" do
             action :nothing
           end
+        }.not_to raise_error
+      end
 
+      it "can use a let variable in a recipe" do
+        expect_converge {
           log "should be able to use let_var as '#{let_var}' with no error."
         }.not_to raise_error
+      end
+
+      it "has access to the driver object" do
+        expect(provisioning_driver.driver_url).to start_with("vagrant:")
       end
     end
   end

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -1,16 +1,18 @@
 describe "Chef::Provisioning::Vagrant" do
-  extend VagrantSupport
+  include_context "run with driver", :driver_string => "vagrant"
 
   when_the_chef_12_server "exists", server_scope: :context, port: 8900..9000 do
-    with_vagrant "integration tests" do
-      context "machine resource" do
-        let(:let_var) { "a let variable in the enclosing context"}
+    context "machine resource" do
+      let(:let_var) { "a let variable in the enclosing context"}
 
-        it "doesn't run any tests" do
-          expect_converge {
-            log "should be able to use let_var as '#{let_var}' with no error."
-          }.not_to raise_error
-        end
+      it "uses a Vagrant resource and a let variable" do
+        expect_converge {
+          vagrant_box "should load the resource with no errors" do
+            action :nothing
+          end
+
+          log "should be able to use let_var as '#{let_var}' with no error."
+        }.not_to raise_error
       end
     end
   end

--- a/spec/vagrant_support.rb
+++ b/spec/vagrant_support.rb
@@ -42,12 +42,3 @@ module VagrantSupport
     when_the_repository "exists and #{description}", *tags, &context_block
   end
 end
-
-# optional, I'm not sure where I cargo-culted this from.
-module VagrantConfig
-  def chef_config
-    @chef_config ||= {
-      driver: Chef::Provisioning.driver_for_url("vagrant"),
-    }
-  end
-end

--- a/spec/vagrant_support.rb
+++ b/spec/vagrant_support.rb
@@ -1,3 +1,5 @@
+abort "ABORT: module VagrantSupport is deprecated. Please use the RSpec shared context instead."
+
 module VagrantSupport
 
   # your top-level context blocks will use this file like so:
@@ -42,3 +44,4 @@ module VagrantSupport
     when_the_repository "exists and #{description}", *tags, &context_block
   end
 end
+


### PR DESCRIPTION
The idea is to package the generic shared context in `chef-provisioning` so any improvements will propagate automatically to any driver using it.

I'm iterating on the code using `chef-provisioning-vagrant` because it's easier: if this is successful, the code will eventually go into `chef-provisioning`.
