### PR TITLE
Allow box_exists? to return a reasonable value when no vagrant boxes are installed

### DIFF
--- a/lib/chef/provider/vagrant_box.rb
+++ b/lib/chef/provider/vagrant_box.rb
@@ -50,7 +50,8 @@ class Chef::Provider::VagrantBox < Chef::Provider::LWRPBase
   # the box name to make sure we have the correct box already installed.
   def box_exists?(new_resource)
     boxes = list_boxes
-    boxes[new_resource.vagrant_provider].has_key?(new_resource.name)
+    provider = new_resource.vagrant_provider
+    boxes.has_key?(provider) && boxes[provider].has_key?(new_resource.name)
   end
 
   def load_current_resource


### PR DESCRIPTION
This commit fixes an upstream issue:
https://github.com/chef/chef-provisioning/issues/418

When no boxes are configured, box_exists? checks a key that will not be present in the box list.  This commit checks whether the provider key exists before looking for the box in that provider list.
