### PR TITLE
Add missing argument on creation of WinRM object

### DIFF
--- a/lib/chef/provisioning/vagrant_driver/driver.rb
+++ b/lib/chef/provisioning/vagrant_driver/driver.rb
@@ -419,7 +419,7 @@ class Chef
             :disable_sspi => true
           }
 
-          Chef::Provisioning::Transport::WinRM.new(endpoint, type, options)
+          Chef::Provisioning::Transport::WinRM.new(endpoint, type, options, config)
         end
 
         def create_ssh_transport(machine_spec)


### PR DESCRIPTION
This PR fixes issue #35 

Provide the required fourth parameter to WinRM.new similar to what is done [here](https://github.com/chef/chef-provisioning-ssh/blob/f680b6a9ec086bfbdb6da654e31e8510680606b4/lib/chef/provisioning/ssh_driver/driver.rb#L168) in the chef-provisioning-ssh driver.
