### PR TITLE
Added 'provides :vagrant_cluster' to fix Chef 13 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 
 language: ruby
 rvm:
-- 2.1.2
+- 2.1.9
+- 2.2.5
+- 2.3.1
 script:
   - bundle exec rake build
   - bundle exec rspec

--- a/lib/chef/provider/vagrant_box.rb
+++ b/lib/chef/provider/vagrant_box.rb
@@ -2,7 +2,7 @@ require 'chef/provider/lwrp_base'
 require 'chef/mixin/shell_out'
 
 class Chef::Provider::VagrantBox < Chef::Provider::LWRPBase
-
+  provides :vagrant_box
   use_inline_resources
 
   include Chef::Mixin::ShellOut

--- a/lib/chef/provider/vagrant_cluster.rb
+++ b/lib/chef/provider/vagrant_cluster.rb
@@ -2,7 +2,7 @@ require 'chef/provider/lwrp_base'
 require 'cheffish'
 
 class Chef::Provider::VagrantCluster < Chef::Provider::LWRPBase
-
+  provides :vagrant_cluster
   use_inline_resources
 
   def whyrun_supported?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'vagrant_support'
+require 'chef/provisioning'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Added 'provides :vagrant_cluster' to make it compatible with Chef 13 (and remove warning if Chef <13).